### PR TITLE
drivers: ipm: fix infinite TXF interrupt

### DIFF
--- a/drivers/ipm/ipm_stm32_ipcc.c
+++ b/drivers/ipm/ipm_stm32_ipcc.c
@@ -135,7 +135,7 @@ static void stm32_ipcc_mailbox_tx_isr(const struct device *dev)
 	mask = (~IPCC_ReadReg(cfg->ipcc, MR)) & IPCC_ALL_MR_TXF_CH_MASK;
 	mask = mask >> IPCC_C1MR_CH1FM_Pos;
 
-	mask &= IPCC_ReadReg_SR(cfg->ipcc) & IPCC_ALL_SR_CH_MASK;
+	mask &= ~IPCC_ReadReg_SR(cfg->ipcc) & IPCC_ALL_SR_CH_MASK;
 
 	for (i = 0; i <  data->num_ch; i++) {
 		if (!((1 << i) & mask)) {


### PR DESCRIPTION
The TXF interrupt mask is not properly set. In this case the interrupt line is not cleaned, leading to the re-entrance in the interrupt handler.

the issue is linked to the management of the IPCC_CxTOCySR value. The TXF interrupt is triggered when the IPCC_CyMR is channel bit is set to 0 and the IPCC_CxTOCySR associated bit move from 1 to 0.

The fix is to check if the IPCC_CxTOCySR channel bit is 0 instead of 1.

Signed-off-by: Arnaud Pouliquen <arnaud.pouliquen@foss.st.com>