### PR TITLE
[RFC] Virtio MMIO device first implementation for stm32mp15  Soc 

### DIFF
--- a/soc/arm/st_stm32/stm32mp1/linker.ld
+++ b/soc/arm/st_stm32/stm32mp1/linker.ld
@@ -14,7 +14,7 @@ MEMORY
 	LINKER_DT_REGIONS()
 
 	/* Used by and documented in include/linker/intlist.ld */
-	MMIO_REGION	(wx)	:	ORIGIN = 0x10050000, LENGTH = 2K
+	MMIO_REGION	(wx)	:	ORIGIN = 0x10050000, LENGTH = 32K
 }
 
 SECTIONS

--- a/soc/arm/st_stm32/stm32mp1/linker.ld
+++ b/soc/arm/st_stm32/stm32mp1/linker.ld
@@ -9,8 +9,16 @@
 
 #include <zephyr/arch/arm/aarch32/cortex_m/scripts/linker.ld>
 
+MEMORY
+{
+	LINKER_DT_REGIONS()
+
+	/* Used by and documented in include/linker/intlist.ld */
+	MMIO_REGION	(wx)	:	ORIGIN = 0x10050000, LENGTH = 2K
+}
+
 SECTIONS
-    {
+{
 
 #include <zephyr/linker/rel-sections.ld>
 #ifdef CONFIG_OPENAMP_RSC_TABLE
@@ -18,6 +26,11 @@ SECTIONS
 	SECTION_PROLOGUE(.resource_table,, SUBALIGN(4))
 	{
 		KEEP(*(.resource_table*))
-    	} GROUP_LINK_IN(ROMABLE_REGION)
+	} GROUP_LINK_IN(ROMABLE_REGION)
 #endif
+
+	SECTION_PROLOGUE(.mmio_table,, SUBALIGN(4))
+	{
+		KEEP(*(.mmio_table*))
+	} GROUP_LINK_IN(MMIO_REGION)
 }


### PR DESCRIPTION
This PR define a shared memory region to store the virtio MMIO register and I2C virtio vrings

The objective of this PR is only to share a first implementation and should not be merged in this state